### PR TITLE
only spot characters owned by a player

### DIFF
--- a/scripts/patrol.js
+++ b/scripts/patrol.js
@@ -35,7 +35,7 @@ class Patrol {
                     spottedToken: undefined,
                 });
             });
-        this.characters = canvas.tokens.placeables.filter((t) => t.actor && (t.actor?.type == "character" || t.actor?.type == "char" || t.actor?.hasPlayerOwner));
+        this.characters = canvas.tokens.placeables.filter((t) => t.actor && (((t.actor?.type == "character" || t.actor?.type == "char") && t.actor?.hasPlayerOwner) || t.actor?.hasPlayerOwner));
     }
 
     async patrolSetDelay(ms) {


### PR DESCRIPTION
This would fix it for my use case. In general I would only check for hasPlayerOwner but I dont know the use-cases so I did not lift the restriction for these two types.

Maybe a general solution would be for the user to provide a list of types for checking, but this might not be easily feasible or needs some tech knowledge or the user.

In case you dont want to put major work into it I would be happy if you can accept my PR